### PR TITLE
Indexed composition

### DIFF
--- a/src/main/scala/core/nat/IFoldAlg.scala
+++ b/src/main/scala/core/nat/IFoldAlg.scala
@@ -3,12 +3,35 @@ package core
 package nat
 
 import scalaz.{ Monad, MonadReader, ~> }
-import scalaz.syntax.functor._
+import scalaz.std.list._
+import scalaz.syntax.monad._
 
 trait IFoldAlg[P[_], Q[_], I, A] extends raw.IFoldAlg[P, I, A]
     with IOpticAlg[P, Q, I, A, MonadReader, List] {
 
   def getList: P[List[(I, A)]] = hom(ev.ask.strengthL)
+
+  /* composing algebras */
+
+  def composeIFold[R[_], J, B](fl: IFoldAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    IFoldAlg(λ[λ[x => ((I, J)) => R[x]] ~> λ[x => P[List[x]]]] { iqx =>
+      map(hom(i => fl.hom(j => iqx((i, j)))))(_.join)
+    })(this, fl.ev)
+
+  def composeIGetter[R[_], J, B](gt: IGetterAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(gt.asIFold)
+
+  def composeITraversal[R[_], J, B](tr: ITraversalAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(tr.asIFold)
+
+  def composeIOptional[R[_], J, B](op: IOptionalAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(op.asIFold)
+
+  def composeIPrism[R[_], J, B](pr: IPrismAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(pr.asIFold)
+
+  def composeILens[R[_], J, B](ln: ILensAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(ln.asIFold)
 }
 
 object IFoldAlg {

--- a/src/main/scala/core/nat/IGetterAlg.scala
+++ b/src/main/scala/core/nat/IGetterAlg.scala
@@ -11,6 +11,29 @@ trait IGetterAlg[P[_], Q[_], I, A] extends raw.IGetterAlg[P, I, A]
 
   def get: P[(I, A)] = hom(ev.ask.strengthL)
 
+  /* composing algebras */
+
+  def composeIFold[R[_], J, B](fl: IFoldAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    asIFold.composeIFold(fl)
+
+  def composeIGetter[R[_], J, B](gt: IGetterAlg[Q, R, J, B]): IGetterAlg[P, R, (I, J), B] =
+    IGetterAlg(new (λ[x => ((I, J)) => R[x]] ~> P) {
+      def apply[X](iqx: ((I, J)) => R[X]): P[X] =
+        hom[X](i => gt.hom[X](j => iqx((i, j))))
+    })(this, gt.ev)
+
+  def composeITraversal[R[_], J, B](tr: ITraversalAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(tr.asIFold)
+
+  def composeIOptional[R[_], J, B](op: IOptionalAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(op.asIFold)
+
+  def composeIPrism[R[_], J, B](pr: IPrismAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    composeIFold(pr.asIFold)
+
+  def composeILens[R[_], J, B](ln: ILensAlg[Q, R, J, B]): IGetterAlg[P, R, (I, J), B] =
+    composeIGetter(ln.asIGetter)
+
   /* transforming algebras */
 
   def asIFold: IFoldAlg[P, Q, I, A] =

--- a/src/main/scala/core/nat/ILensAlg.scala
+++ b/src/main/scala/core/nat/ILensAlg.scala
@@ -16,13 +16,29 @@ trait ILensAlg[P[_], Q[_], I, A] extends raw.ILensAlg[P, I, A]
 
   /* composing algebras */
 
-  def composeIOptional[R[_], J, B](
-      opt: IOptionalAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
-    IOptionalAlg[P, R, (I, J), B](
-      λ[λ[x => ((I, J)) => R[x]] ~> λ[y => P[Option[y]]]] { irx =>
-        hom(i => opt.hom(j => irx((i, j))))
-      }
-    )(this, opt.ev)
+  def composeIFold[R[_], J, B](fl: IFoldAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    asIFold.composeIFold(fl)
+
+  def composeIGetter[R[_], J, B](gt: IGetterAlg[Q, R, J, B]): IGetterAlg[P, R, (I, J), B] =
+    asIGetter.composeIGetter(gt)
+
+  def composeISetter[R[_], J, B](st: ISetterAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    asISetter.composeISetter(st)
+
+  def composeITraversal[R[_], J, B](tr: ITraversalAlg[Q, R, J, B]): ITraversalAlg[P, R, (I, J), B] =
+    asITraversal.composeITraversal(tr)
+
+  def composeIOptional[R[_], J, B](op: IOptionalAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
+    asIOptional.composeIOptional(op)
+
+  def composeIPrism[R[_], J, B](pr: IPrismAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
+    asIOptional.composeIOptional(pr.asIOptional)
+
+  def composeILens[R[_], J, B](ln: ILensAlg[Q, R, J, B]): ILensAlg[P, R, (I, J), B] =
+    ILensAlg(new (λ[x => ((I, J)) => R[x]] ~> P) {
+      def apply[X](iqx: ((I, J)) => R[X]): P[X] =
+        hom[X](i => ln.hom[X](j => iqx((i, j))))
+    })(this, ln.ev)
 
   /* transforming algebras */
 

--- a/src/main/scala/core/nat/IOptionalAlg.scala
+++ b/src/main/scala/core/nat/IOptionalAlg.scala
@@ -3,7 +3,8 @@ package core
 package nat
 
 import scalaz.{ Monad, MonadState, ~> }
-import scalaz.syntax.functor._
+import scalaz.syntax.monad._
+import scalaz.std.option._
 
 trait IOptionalAlg[P[_], Q[_], I, A] extends raw.IOptionalAlg[P, I, A]
     with IOpticAlg[P, Q, I, A, MonadState, Option] {
@@ -11,6 +12,31 @@ trait IOptionalAlg[P[_], Q[_], I, A] extends raw.IOptionalAlg[P, I, A]
   def getOption: P[Option[(I, A)]] = hom(ev.get.strengthL)
 
   def setOption(a: A): P[Option[Unit]] = hom(_ => ev.put(a))
+
+  /* composing algebras */
+
+  def composeIFold[R[_], J, B](fl: IFoldAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    asIFold.composeIFold(fl)
+
+  def composeIGetter[R[_], J, B](gt: IGetterAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    asIFold.composeIFold(gt.asIFold)
+
+  def composeISetter[R[_], J, B](st: ISetterAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    asISetter.composeISetter(st)
+
+  def composeITraversal[R[_], J, B](tr: ITraversalAlg[Q, R, J, B]): ITraversalAlg[P, R, (I, J), B] =
+    asITraversal.composeITraversal(tr)
+
+  def composeIOptional[R[_], J, B](op: IOptionalAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
+    IOptionalAlg(λ[λ[x => ((I, J)) => R[x]] ~> λ[x => P[Option[x]]]] { iqx =>
+      map(hom(i => op.hom(j => iqx((i, j)))))(_.join)
+    })(this, op.ev)
+
+  def composeIPrism[R[_], J, B](pr: IPrismAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
+    composeIOptional(pr.asIOptional)
+
+  def composeILens[R[_], J, B](ln: ILensAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
+    composeIOptional(ln.asIOptional)
 
   /* transforming algebras */
 

--- a/src/main/scala/core/nat/IPrismAlg.scala
+++ b/src/main/scala/core/nat/IPrismAlg.scala
@@ -3,7 +3,8 @@ package core
 package nat
 
 import scalaz.{ Monad, MonadState, ~> }
-import scalaz.syntax.functor._
+import scalaz.syntax.monad._
+import scalaz.std.option._
 
 trait IPrismAlg[P[_], Q[_], I, A] extends raw.IPrismAlg[P, I, A]
     with IOpticAlg[P, Q, I, A, MonadState, Option] {
@@ -11,6 +12,31 @@ trait IPrismAlg[P[_], Q[_], I, A] extends raw.IPrismAlg[P, I, A]
   def getOption: P[Option[(I, A)]] = hom(ev.get.strengthL)
 
   def set(a: A): P[Unit] = map(hom(_ => ev.put(a)))(_.get)
+
+  /* composing algebras */
+
+  def composeIFold[R[_], J, B](fl: IFoldAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    asIFold.composeIFold(fl)
+
+  def composeIGetter[R[_], J, B](gt: IGetterAlg[Q, R, J, B]): IFoldAlg[P, R, (I, J), B] =
+    asIFold.composeIFold(gt.asIFold)
+
+  def composeISetter[R[_], J, B](st: ISetterAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    asISetter.composeISetter(st)
+
+  def composeITraversal[R[_], J, B](tr: ITraversalAlg[Q, R, J, B]): ITraversalAlg[P, R, (I, J), B] =
+    asITraversal.composeITraversal(tr)
+
+  def composeIOptional[R[_], J, B](op: IOptionalAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
+    asIOptional.composeIOptional(op)
+
+  def composeIPrism[R[_], J, B](pr: IPrismAlg[Q, R, J, B]): IPrismAlg[P, R, (I, J), B] =
+    IPrismAlg(λ[λ[x => ((I, J)) => R[x]] ~> λ[x => P[Option[x]]]] { iqx =>
+      map(hom(i => pr.hom(j => iqx((i, j)))))(_.join)
+    })(this, pr.ev)
+
+  def composeILens[R[_], J, B](ln: ILensAlg[Q, R, J, B]): IOptionalAlg[P, R, (I, J), B] =
+    asIOptional.composeIOptional(ln.asIOptional)
 
   /* transforming algebras */
 

--- a/src/main/scala/core/nat/ISetterAlg.scala
+++ b/src/main/scala/core/nat/ISetterAlg.scala
@@ -8,6 +8,23 @@ trait ISetterAlg[P[_], Q[_], I, A] extends raw.ISetterAlg[P, I, A]
     with IOpticAlg[P, Q, I, A, MonadState, Const[Unit, ?]] {
 
   def modify(f: A => A): P[Unit] = map(hom(_ => ev.modify(f)))(_.getConst)
+
+  def composeISetter[R[_], J, B](st: ISetterAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    ISetterAlg(λ[λ[x => ((I, J)) => R[x]] ~> λ[x => P[Const[Unit, x]]]] { iqx =>
+      map(hom(i => st.hom(j => iqx((i, j)))))(_ => Const(()))
+    })(this, st.ev)
+
+  def composeITraversal[R[_], J, B](tr: ITraversalAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    composeISetter(tr.asISetter)
+
+  def composeIOptional[R[_], J, B](op: IOptionalAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    composeISetter(op.asISetter)
+
+  def composeIPrism[R[_], J, B](pr: IPrismAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    composeISetter(pr.asISetter)
+
+  def composeILens[R[_], J, B](ln: ILensAlg[Q, R, J, B]): ISetterAlg[P, R, (I, J), B] =
+    composeISetter(ln.asISetter)
 }
 
 object ISetterAlg {


### PR DESCRIPTION
Enables the composition among *indexed optics*. When we compose an optic whose index is `I` and another one whose index is `J`, we end up with a new optic whose index is `(I, J)`. Dealing with this kind of combinators is annoying for users, since several consecutive combinations lead to ugly nested tuples as indexes. `HList` is undoubtedly a better approach than tuples, but this is not a priority right now. Instead, we need running examples!